### PR TITLE
Fix update-model workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,7 +36,7 @@ jobs:
             echo "SCHEMA_VERSION=${LATEST_VERSION:1}" >> $GITHUB_ENV
           fi
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Generate test database

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate test database
         if: env.NEEDS_UPDATE == 1
         run: |
-          sudo apt-get update && sudo apt-get install -y mariadb-client-10.3
+          sudo apt-get update && sudo apt-get install -y mariadb-client
           cat >~/.my.cnf <<EOF
           [client]
           user=root

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -37,6 +37,8 @@ jobs:
           fi
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Generate test database
         if: env.NEEDS_UPDATE == 1
         run: |


### PR DESCRIPTION
Two dependancy issues were causing the workflow to fail:
- un-pinned mariadb-client version
- pinned python version to 3.10